### PR TITLE
Adds Dockerfile and docker-compose config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the requirements file into the container
+COPY requirements.txt requirements.txt
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Default CMD is the help command of run_job.py
+CMD ["python", "./run_job.py", "-h"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  ck: &ck
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ck
+  dev:
+    <<: *ck
+    tty: true
+    stdin_open: true
+    volumes:
+      - .:/app
+    command: ["bash"]
+    
+  
+  


### PR DESCRIPTION
This is just a starting point for running SWT in docker as an alternative to installing Python virtual environments.

Build image (if not already built) and start an interactive `bash` shell with the host's current working directory mounted to `/usr/src/app/`. No ports forwarded by default, but feel free to add if it makes sense. Note the `--rm` option will automatically remove the image once it stops, which avoids clutter for unused images over time.

    docker-compose run --rm dev

Start it in one window, connect in another....

    # In first terminal...
    # Ctrl+C or closing termrinal window stops the container. Can view STDOUT.
    docker-compose up dev

    # In 2nd terminal...
    # Shell into running container.
    # Ctrl+C closes session, but does not stop container
    docker exec -it clams-kitchen-dev-1 bash

Rebuild the image as needed.

    docker-compose build --no-cache dev